### PR TITLE
Add some more details to output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -728,6 +728,7 @@ fn check_test(
     // funcs (subtests) -> vals (args/returns) -> fields -> bytes
 
     let mut results: Vec<Result<(), CheckFailure>> = Vec::new();
+    let full_test_name = full_test_name(test_key);
 
     // Layer 1 is the funcs/subtests. Because we have already checked
     // that they agree on their lengths, we can zip them together
@@ -864,9 +865,9 @@ fn check_test(
     }
 
     if all_passed {
-        eprintln!("all tests passed");
-    } else {
-        eprintln!("only {}/{} tests passed!", num_passed, results.len());
+        eprintln!("all tests from set {full_test_name} passed");
+    } else { 
+        eprintln!("only {}/{} tests from set {full_test_name} passed!", num_passed, results.len());
     }
     eprintln!();
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -309,6 +309,7 @@ impl FullReport {
     pub fn print_human(&self, mut f: impl std::io::Write) -> Result<(), std::io::Error> {
         use TestCheckMode::*;
         use TestConclusion::*;
+        eprintln!();
         writeln!(f, "Final Results:")?;
 
         for test in &self.tests {
@@ -366,7 +367,7 @@ impl FullReport {
         writeln!(f)?;
         writeln!(
             f,
-            "{} tests run - {} passed, {} busted, {} failed, {} skipped",
+            "{} test sets run - {} passed, {} busted, {} failed, {} skipped",
             self.summary.num_tests,
             self.summary.num_passed,
             self.summary.num_busted,


### PR DESCRIPTION
-   Print test set name when it passes or fails
-   Clarify that the numbers at the end of final results are for test sets and
    not the total subtests run
-   Add extra spacing above "Final Results:" so it doesn't blend into the test
    output