### PR TITLE
Begin prototyping f128 tests

### DIFF
--- a/src/abis.rs
+++ b/src/abis.rs
@@ -227,6 +227,7 @@ pub enum IntVal {
 pub enum FloatVal {
     c_double(f64),
     c_float(f32),
+    c_float128(f64),
     // Is there a reason to mess with `long double`? Surely not.
 }
 

--- a/src/abis/c.rs
+++ b/src/abis/c.rs
@@ -610,6 +610,7 @@ impl CcAbiImpl {
                 ));
             }
             Struct(name, _) => format!("struct {name}"),
+            Float(FloatVal::c_float128(_)) => "__float128".to_string(),
             Float(FloatVal::c_double(_)) => "double".to_string(),
             Float(FloatVal::c_float(_)) => "float".to_string(),
             Int(int_val) => match int_val {
@@ -679,6 +680,13 @@ impl CcAbiImpl {
                 }
                 output.push_str(" }");
                 output
+            }
+            Float(FloatVal::c_float128(val)) => {
+                if val.fract() == 0.0 {
+                    format!("{val}.0")
+                } else {
+                    format!("{val}")
+                }
             }
             Float(FloatVal::c_double(val)) => {
                 if val.fract() == 0.0 {

--- a/src/abis/rust.rs
+++ b/src/abis/rust.rs
@@ -442,6 +442,9 @@ impl RustcAbiImpl {
             Bool(_) => "bool".to_string(),
             Array(vals) => format!("[{}; {}]", self.rust_arg_type(&vals[0])?, vals.len()),
             Struct(name, _) => name.to_string(),
+            Float(FloatVal::c_float128(_)) => {
+                return Err(GenerateError::RustUnsupported("f128".to_owned()))
+            }
             Float(FloatVal::c_double(_)) => "f64".to_string(),
             Float(FloatVal::c_float(_)) => "f32".to_string(),
             Int(int_val) => match int_val {
@@ -508,6 +511,13 @@ impl RustcAbiImpl {
                 }
                 output.push_str(" }");
                 output
+            }
+            Float(FloatVal::c_float128(val)) => {
+                if val.fract() == 0.0 {
+                    format!("{val}.0")
+                } else {
+                    format!("{val}")
+                }
             }
             Float(FloatVal::c_double(val)) => {
                 if val.fract() == 0.0 {

--- a/src/procgen.rs
+++ b/src/procgen.rs
@@ -38,6 +38,7 @@ pub fn procgen_tests(regenerate: bool) {
         ("u8", &[Val::Int(IntVal::c_uint8_t(0x1a))]),
         ("ptr", &[Val::Ptr(0x1a2b_3c4d_23ea_f142)]),
         ("bool", &[Val::Bool(true)]),
+        ("f128", &[Val::Float(FloatVal::c_float128(809239021.392))]),
         ("f64", &[Val::Float(FloatVal::c_double(809239021.392))]),
         ("f32", &[Val::Float(FloatVal::c_float(-4921.3527))]),
         // These are split out because they are the buggy mess that inspired this whole enterprise!
@@ -99,6 +100,7 @@ pub fn procgen_tests(regenerate: bool) {
                         Val::Float(float_val) => match float_val {
                             FloatVal::c_double(out) => graffiti_primitive(out, i),
                             FloatVal::c_float(out) => graffiti_primitive(out, i),
+                            FloatVal::c_float128(out) => graffiti_primitive(out, i),
                         },
                         Val::Bool(out) => *out = true,
                     }
@@ -342,6 +344,7 @@ pub fn arg_ty(val: &Val) -> String {
             arg_ty(vals.get(0).expect("arrays must have length > 0")),
         ),
         Struct(name, _) => format!("struct_{name}"),
+        Float(FloatVal::c_float128(_)) => "f128".to_string(),
         Float(FloatVal::c_double(_)) => "f64".to_string(),
         Float(FloatVal::c_float(_)) => "f32".to_string(),
         Int(int_val) => match int_val {

--- a/src/report.rs
+++ b/src/report.rs
@@ -26,7 +26,9 @@ pub fn get_test_rules(test: &TestKey, caller: &dyn AbiImpl, callee: &dyn AbiImpl
     // This is Bad! Ideally we should check for all clang<->gcc pairs but to start
     // let's mark rust <-> C as disagreeing (because rust also disagrees with clang).
     if !cfg!(any(target_arch = "aarch64", target_arch = "s390x"))
-        && test.test_name == "ui128" && is_rust_and_c {
+        && test.test_name == "ui128"
+        && is_rust_and_c
+    {
         result.check = Busted(Check);
     }
 

--- a/tests/normal/f128.ron
+++ b/tests/normal/f128.ron
@@ -1,0 +1,11 @@
+Test(
+    name: "f128",  
+    funcs: [
+        (
+            name: "f128",
+            conventions: [c],
+            inputs: [Float(c_float128(5))],
+            output: None,
+        ),
+    ]
+)


### PR DESCRIPTION
@Gankra I think I need some help completing this (unless you'd prefer to pick it up). Do you have any suggestions for how to get __float128 to work since Rust doesn't have an internal representation? It is supported on both GCC and Clang x86/s390x/some mips.

I'm trying to figure this out because (1) Rust is getting close to adding a f128 type, and (2) LLVM is getting very close to fixing their i128 representation - just want to make sure that everything seems to be on the same page as those start to land.