### PR TITLE
fix some wrong tests and add some new ones

### DIFF
--- a/include/tests/normal/simple.kdl
+++ b/include/tests/normal/simple.kdl
@@ -13,7 +13,7 @@ fn "print" {
 
 fn "scale" {
     inputs { _ "Point3"; factor "f32"; }
-    output { "Point3"; }
+    outputs { "Point3"; }
 }
 
 fn "add" {

--- a/include/tests/procgen/struct/TwoAlignedU32s.procgen.kdl
+++ b/include/tests/procgen/struct/TwoAlignedU32s.procgen.kdl
@@ -1,0 +1,9 @@
+// This was a problem for rustc (I think u32 = ulong here?)
+//
+// https://github.com/rust-lang/rust/issues/80127
+
+@align 16
+struct "TwoU32s" {
+    a "u32"
+    b "u32"
+}

--- a/include/tests/procgen/struct/TwoAlignedU64s.procgen.kdl
+++ b/include/tests/procgen/struct/TwoAlignedU64s.procgen.kdl
@@ -1,0 +1,9 @@
+// This was a problem for rustc on ppc64le
+//
+// https://github.com/rust-lang/rust/issues/122767
+
+@align 16
+struct "TwoU64s" {
+    a "u64"
+    b "u64"
+}

--- a/include/tests/procgen/tagged/OptionI32.procgen.kdl
+++ b/include/tests/procgen/tagged/OptionI32.procgen.kdl
@@ -1,6 +1,6 @@
 // An option-like enum of i32
 
-tagged "OptI32Tagged" {
+tagged "OptionI32" {
     Some { _ "i32"; }
     None
 }

--- a/include/tests/procgen/tagged/OptionU128.procgen.kdl
+++ b/include/tests/procgen/tagged/OptionU128.procgen.kdl
@@ -1,0 +1,8 @@
+// This type was a problem for cranelift
+//
+// https://github.com/rust-lang/rustc_codegen_cranelift/issues/1449
+
+tagged "OptionU128" {
+  Some { _ "u128"; }
+  None
+}

--- a/include/tests/procgen/union/MultiVariantUnion.procgen.kdl
+++ b/include/tests/procgen/union/MultiVariantUnion.procgen.kdl
@@ -1,6 +1,7 @@
 union "MultiVariantUnion" {
     _ "u32"
     _ "i64"
+    _ "Point3"
 }
 
 struct "Point3" {


### PR DESCRIPTION
Note that C still doesn't implement align, but as of #39 we combinatoric repr(rust) vs repr(c) and include rustcall as a calling convention, so our coverage of rust <-> rust (in particular for codegen_backend users) is significantly improved.

fixes #23
fixes #21
fixes #15