### PR TITLE
fix: fix broken tests and make test parse a hard error

### DIFF
--- a/include/tests/normal/simple.kdl
+++ b/include/tests/normal/simple.kdl
@@ -13,7 +13,7 @@ fn "print" {
 
 fn "scale" {
     inputs { _ "Point3"; factor "f32"; }
-    outputs { "Point3"; }
+    outputs { _ "Point3"; }
 }
 
 fn "add" {

--- a/include/tests/procgen/struct/TwoAlignedU32s.procgen.kdl
+++ b/include/tests/procgen/struct/TwoAlignedU32s.procgen.kdl
@@ -3,7 +3,7 @@
 // https://github.com/rust-lang/rust/issues/80127
 
 @align 16
-struct "TwoU32s" {
+struct "TwoAlignedU32s" {
     a "u32"
     b "u32"
 }

--- a/include/tests/procgen/struct/TwoAlignedU64s.procgen.kdl
+++ b/include/tests/procgen/struct/TwoAlignedU64s.procgen.kdl
@@ -3,7 +3,7 @@
 // https://github.com/rust-lang/rust/issues/122767
 
 @align 16
-struct "TwoU64s" {
+struct "TwoAlignedU64s" {
     a "u64"
     b "u64"
 }

--- a/kdl-script/src/lib.rs
+++ b/kdl-script/src/lib.rs
@@ -115,22 +115,6 @@ impl Compiler {
         }
         Ok(None)
     }
-
-    /*
-    fn diagnose(&mut self, err: KdlScriptError) {
-        use ErrorMode::*;
-        use ErrorStyle::*;
-        match &mut self.error_handler {
-            ErrorHandler {
-                error_mode: Scream,
-                error_style: Human,
-            } => {
-                eprintln!("{:?}", miette::Report::new(err));
-            }
-            _ => todo!(),
-        }
-    }
-     */
 }
 
 impl Default for Compiler {

--- a/kdl-script/src/spanned.rs
+++ b/kdl-script/src/spanned.rs
@@ -25,6 +25,7 @@ impl<T> Spanned<T> {
             end: span.offset() + span.len(),
         }
     }
+
     /// Access the start of the span of the contained value.
     pub fn start(this: &Self) -> usize {
         this.start
@@ -33,6 +34,12 @@ impl<T> Spanned<T> {
     /// Access the end of the span of the contained value.
     pub fn end(this: &Self) -> usize {
         this.end
+    }
+
+    // Acquire the span of the input
+    pub fn clone_span_from<U>(this: &mut Self, other: &Spanned<U>) {
+        this.start = other.start;
+        this.end = other.end;
     }
 
     /// Update the span

--- a/kdl-script/src/tests/type_pass.rs
+++ b/kdl-script/src/tests/type_pass.rs
@@ -72,7 +72,7 @@ fn c_enum_literals2() -> Result<(), miette::Report> {
 
 #[test]
 fn c_enum_literals3() -> Result<(), miette::Report> {
-    // TODO: this one might be dubious? Check what C/C++ allow with puns here
+    // FIXME: this one might be dubious? Check what C/C++ allow with puns here
     let program = r##"
         enum "Cases" {
             A 8

--- a/kdl-script/src/types.rs
+++ b/kdl-script/src/types.rs
@@ -64,7 +64,7 @@ pub struct KdlScriptTypeError {
     pub src: Arc<NamedSource>,
     #[label]
     pub span: SourceSpan,
-    #[help]
+    #[diagnostic(help)]
     pub help: Option<String>,
 }
 
@@ -724,7 +724,7 @@ impl TyCtx {
                     ty_idx
                 } else {
                     return Err(KdlScriptTypeError {
-                        message: "use of undefined type name".to_string(),
+                        message: format!("use of undefined type name: {name}"),
                         src: self.src.clone(),
                         span: Spanned::span(name),
                         help: None,

--- a/src/abis/c/init.rs
+++ b/src/abis/c/init.rs
@@ -110,7 +110,6 @@ impl CcAbiImpl {
                 // The value is a mutable reference to a temporary
                 write!(f, "&{ref_temp_name}")?;
 
-                // TODO: should this be a recursive call to create_var (need create_var_inner?)
                 // Now do the rest of the recursion on constructing the temporary
                 let mut ref_temp = String::new();
                 let mut ref_temp_f = Fivemat::new(&mut ref_temp, INDENT);

--- a/src/abis/rust/init.rs
+++ b/src/abis/rust/init.rs
@@ -84,8 +84,6 @@ impl RustcAbiImpl {
             Ty::Ref(RefTy { pointee_ty }) => {
                 // The value is a mutable reference to a temporary
                 write!(f, "&mut {ref_temp_name}")?;
-
-                // TODO: should this be a recursive call to create_var (need create_var_inner?)
                 // Now do the rest of the recursion on constructing the temporary
                 let mut ref_temp = String::new();
                 let mut ref_temp_f = Fivemat::new(&mut ref_temp, INDENT);

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,7 @@
 use miette::Diagnostic;
 
+use crate::TestId;
+
 #[derive(Debug, thiserror::Error, Diagnostic)]
 pub enum CliParseError {
     #[error("{0}")]
@@ -39,6 +41,19 @@ pub enum GenerateError {
         block2: String,
         block2_val_count: usize,
     },
+    #[error("failed to read and parse test {test}")]
+    ReadTest {
+        test: TestId,
+        #[source]
+        #[diagnostic_source]
+        details: Box<GenerateError>,
+    },
+}
+
+impl std::borrow::Borrow<dyn Diagnostic> for Box<GenerateError> {
+    fn borrow(&self) -> &(dyn Diagnostic + 'static) {
+        &**self
+    }
 }
 
 #[derive(Debug, thiserror::Error, Diagnostic)]

--- a/src/harness/read.rs
+++ b/src/harness/read.rs
@@ -100,13 +100,12 @@ pub fn spawn_read_test(
 
 /// Read a test .kdl file
 async fn read_test(test: TestId, test_file: TestFile) -> Result<Arc<Test>, GenerateError> {
-    read_test_inner(&test, test_file).await.map_err(|e| {
-        warn!(
-            "failed to read and parse test {test}, skipping\n{:?}",
-            miette::Report::new(e)
-        );
-        GenerateError::Skipped
-    })
+    read_test_inner(&test, test_file)
+        .await
+        .map_err(|e| GenerateError::ReadTest {
+            test,
+            details: Box::new(e),
+        })
 }
 
 async fn read_test_inner(test: &TestId, test_file: TestFile) -> Result<Arc<Test>, GenerateError> {

--- a/src/report.rs
+++ b/src/report.rs
@@ -440,7 +440,7 @@ impl FullReport {
             let (status, status_message) = match test.conclusion {
                 TestConclusion::Skipped => continue,
                 TestConclusion::Passed => ("ok", None),
-                TestConclusion::Failed => ("failed", Some("todo fill this message in")),
+                TestConclusion::Failed => ("failed", Some("FIXME fill this message in")),
                 TestConclusion::Busted => ("ok", None),
             };
             let test_name = harness.full_test_name(&test.key);


### PR DESCRIPTION
Also several cleanups to the parsing/errors to properly produce spans/context.

I keep checking in broken test files and not noticing because the test harness considers it ok for a test to fail to parse/type (emitting a warning that gets buried by test output immediately). there's literally no reason to be permissive in this case, as the tests loading/parsing isn't platform specific, and there's no reason to toss non-tests in these dirs.