### PR TITLE
Added a test checking the proc-macro interface

### DIFF
--- a/include/tests/normal/ProcMacro.kdl
+++ b/include/tests/normal/ProcMacro.kdl
@@ -1,0 +1,20 @@
+struct "Buffer" {
+    data "ptr"
+    len "ptr"
+    capacity "ptr"
+    reserve "ptr"
+    drop "ptr"
+}
+struct "Closure" {
+	call "ptr"
+	env "ptr"
+}
+struct "BufferConfig" {
+    input "Buffer"
+    dispatch "Closure"
+    force_show_panics "bool"
+}
+fn "derive_macro" {
+	inputs { config "BufferConfig"; }
+	outputs { buffer "Buffer"; }
+}


### PR DESCRIPTION
As the title says. This test is a recreation of the proc-macro library / compiler interface. 

Since this is one of the places where compiler backends most often interact, checking it seems worthwhile. This particular test currently fails with  `cg_gcc` on ARM. 

I could not find a good way to test the `usize` type, so I replaced it with `ptr`, to keep it's size right across platforms.

