### PR TITLE
add support for `f80`

### DIFF
--- a/kdl-script/src/types.rs
+++ b/kdl-script/src/types.rs
@@ -205,6 +205,8 @@ pub enum PrimitiveTy {
     Bool,
     /// An opaque pointer (like `void*`)
     Ptr,
+    /// `x86_fp80` / `long double` on x86 and x86_64
+    X86f80,
 }
 
 pub const PRIMITIVES: &[(&str, PrimitiveTy)] = &[
@@ -222,6 +224,7 @@ pub const PRIMITIVES: &[(&str, PrimitiveTy)] = &[
     ("u256", PrimitiveTy::U256),
     ("f16", PrimitiveTy::F16),
     ("f32", PrimitiveTy::F32),
+    ("f80", PrimitiveTy::X86f80),
     ("f64", PrimitiveTy::F64),
     ("f128", PrimitiveTy::F128),
     ("bool", PrimitiveTy::Bool),

--- a/src/toolchains/c/declare.rs
+++ b/src/toolchains/c/declare.rs
@@ -160,6 +160,18 @@ impl CcToolchain {
                             ))?,
                         }
                     }
+                    PrimitiveTy::X86f80 => {
+                        if cfg!(all(
+                            any(target_arch = "x86", target_arch = "x86_64"),
+                            not(any(target_os = "windows", target_os = "uefi")),
+                        )) {
+                            "long double "
+                        } else {
+                            Err(UnsupportedError::Other(
+                                "x86_f80 is not supported on this target".to_owned(),
+                            ))?
+                        }
+                    }
                 };
                 (name.to_owned(), None)
             }
@@ -261,6 +273,7 @@ impl CcToolchain {
                     | PrimitiveTy::F16
                     | PrimitiveTy::F32
                     | PrimitiveTy::F64
+                    | PrimitiveTy::X86f80
                     | PrimitiveTy::F128
                     | PrimitiveTy::Bool
                     | PrimitiveTy::Ptr => {
@@ -388,6 +401,7 @@ impl CcToolchain {
                     | PrimitiveTy::F16
                     | PrimitiveTy::F32
                     | PrimitiveTy::F64
+                    | PrimitiveTy::X86f80
                     | PrimitiveTy::F128
                     | PrimitiveTy::Bool
                     | PrimitiveTy::Ptr => {

--- a/src/toolchains/c/init.rs
+++ b/src/toolchains/c/init.rs
@@ -86,6 +86,17 @@ impl CcToolchain {
                         "(((union {{ __uint128_t bits; __float128 value; }}){{ .bits = ((__uint128_t){lower:#X}ull) | (((__uint128_t){higher:#X}ull) << 64) }}).value)"
                     )?
                 }
+                PrimitiveTy::X86f80 => {
+                    // Limit to 80 bits / 10 bytes.
+                    let val = val.generate_u128() & 0x0000_0000_0000_FFFF_FFFF_FFFF_FFFF_FFFF;
+
+                    let lower = val & 0x0000_0000_0000_0000_FFFF_FFFF_FFFF_FFFF;
+                    let higher = (val & 0xFFFF_FFFF_FFFF_FFFF_0000_0000_0000_0000) >> 64;
+                    write!(
+                        f,
+                        "(((union {{ __uint128_t bits; long double value; }}){{ .bits = ((__uint128_t){lower:#X}ull) | (((__uint128_t){higher:#X}ull) << 64) }}).value)"
+                    )?
+                }
             },
             Ty::Enum(enum_ty) => {
                 let name = alias.unwrap_or(&enum_ty.name);

--- a/src/toolchains/c/write.rs
+++ b/src/toolchains/c/write.rs
@@ -259,7 +259,13 @@ impl CcToolchain {
                 } else {
                     path
                 };
-                writeln!(f, "write_val({to}, {val_idx}, {rvalue});")?;
+
+                if let Ty::Primitive(PrimitiveTy::X86f80) = state.types.realize_ty(val.ty) {
+                    // Only the first 10 bytes of an x86_f80 value are meaningful.
+                    writeln!(f, "WRITE_VAL({to}, {val_idx}, (char*)&{rvalue}, 10);")?;
+                } else {
+                    writeln!(f, "write_val({to}, {val_idx}, {rvalue});")?;
+                }
             }
             WriteImpl::Assert => {
                 write!(f, "assert_eq({path}, ")?;

--- a/src/toolchains/rust/declare.rs
+++ b/src/toolchains/rust/declare.rs
@@ -102,6 +102,9 @@ impl RustcToolchain {
                             ))?;
                         }
                     }
+                    PrimitiveTy::X86f80 => Err(UnsupportedError::Other(
+                        "rust doesn't have x86_f80".to_owned(),
+                    ))?,
                 };
                 (name.to_owned(), None)
             }
@@ -296,6 +299,7 @@ impl RustcToolchain {
                     | PrimitiveTy::F32
                     | PrimitiveTy::F64
                     | PrimitiveTy::F128
+                    | PrimitiveTy::X86f80
                     | PrimitiveTy::Bool
                     | PrimitiveTy::Ptr => {
                         // Builtin
@@ -359,6 +363,7 @@ impl RustcToolchain {
                                 | PrimitiveTy::F32
                                 | PrimitiveTy::F64
                                 | PrimitiveTy::F128
+                                | PrimitiveTy::X86f80
                                 | PrimitiveTy::Bool
                                 | PrimitiveTy::Ptr => {
                                     return Err(UnsupportedError::Other(format!(

--- a/src/toolchains/rust/init.rs
+++ b/src/toolchains/rust/init.rs
@@ -44,6 +44,9 @@ impl RustcToolchain {
                 }
                 PrimitiveTy::F16 => write!(f, "f16::from_bits({})", val.generate_u16())?,
                 PrimitiveTy::F128 => write!(f, "f128::from_bits({})", val.generate_u128())?,
+                PrimitiveTy::X86f80 => Err(UnsupportedError::Other(
+                    "rust doesn't have x86_f80".to_owned(),
+                ))?,
             },
             Ty::Enum(enum_ty) => {
                 let name = alias.unwrap_or(&enum_ty.name);


### PR DESCRIPTION
We're [working on](https://github.com/rust-lang/rust-project-goals/issues/701) adding support for (what we will call) `x87_f80`, a.k.a. `f80` or `x86_fpf80` or `long double` on x86 targets, to rust. Being able to thoroughly check that we're doing that right ABI-wise is helpful.

We could bikeshed the name, I don't particularly care, `f80` seemed simplest.

FYI: I'm also looking at the powerpc "double double" `f128` type, and `_Complex`. Those would really benefit from cross-compilation, but adding it does not seem entirely straightforward. 