### PR TITLE
fix alias of struct vs argument perturb codegen

### DIFF
--- a/src/harness/read/procgen.rs
+++ b/src/harness/read/procgen.rs
@@ -122,7 +122,7 @@ fn add_perturbs_struct(
         // Add the function
         add_func(
             out,
-            &format!("val_in_{idx}_perturbed_{label}"),
+            &format!("struct_in_{idx}_perturbed_{label}"),
             &[&struct_ty],
             &[],
         )?;


### PR DESCRIPTION
The names added by `add_perturbs` and `add_perturbs_struct` would alias, hiding potential failures.