### PR TITLE
Use `__float128` or `_Float128` depending on the target

### DIFF
--- a/src/toolchains/c/init.rs
+++ b/src/toolchains/c/init.rs
@@ -78,12 +78,16 @@ impl CcToolchain {
                     val.generate_u16()
                 )?,
                 PrimitiveTy::F128 => {
+                    // Pick `__float128` or `_Float128` depending on the target.
+                    let (f128_ty_name, _) = &state.tynames[&ty];
+                    let f128_ty_name = f128_ty_name.trim_end();
+
                     let val = val.generate_u128();
                     let lower = val & 0x0000_0000_0000_0000_FFFF_FFFF_FFFF_FFFF;
                     let higher = (val & 0xFFFF_FFFF_FFFF_FFFF_0000_0000_0000_0000) >> 64;
                     write!(
                         f,
-                        "(((union {{ __uint128_t bits; __float128 value; }}){{ .bits = ((__uint128_t){lower:#X}ull) | (((__uint128_t){higher:#X}ull) << 64) }}).value)"
+                        "(((union {{ __uint128_t bits; {f128_ty_name} value; }}){{ .bits = ((__uint128_t){lower:#X}ull) | (((__uint128_t){higher:#X}ull) << 64) }}).value)"
                     )?
                 }
             },


### PR DESCRIPTION
I hit this with `riscv64gc-unknown-linux-gnu`. Using the name we already determine elsewhere should work.