### PR TITLE
32-bit C does not support `__int128_t`

### DIFF
--- a/src/toolchains/c/declare.rs
+++ b/src/toolchains/c/declare.rs
@@ -53,6 +53,8 @@ impl CcToolchain {
             return Ok(());
         }
 
+        let has_128bit_int = cfg!(target_pointer_width = "64") || cfg!(target_family = "wasm");
+
         let (prefix, suffix) = match state.types.realize_ty(ty) {
             // Structural types that don't need definitions but we should
             // intern the name of
@@ -62,12 +64,18 @@ impl CcToolchain {
                     PrimitiveTy::I16 => "int16_t ",
                     PrimitiveTy::I32 => "int32_t ",
                     PrimitiveTy::I64 => "int64_t ",
-                    PrimitiveTy::I128 => "__int128_t ",
+                    PrimitiveTy::I128 if has_128bit_int => "__int128_t ",
+                    PrimitiveTy::I128 => Err(UnsupportedError::Other(
+                        "32-bit and 16-bit c don't have i128?".to_owned(),
+                    ))?,
                     PrimitiveTy::U8 => "uint8_t ",
                     PrimitiveTy::U16 => "uint16_t ",
                     PrimitiveTy::U32 => "uint32_t ",
                     PrimitiveTy::U64 => "uint64_t ",
-                    PrimitiveTy::U128 => "__uint128_t ",
+                    PrimitiveTy::U128 if has_128bit_int => "__uint128_t ",
+                    PrimitiveTy::U128 => Err(UnsupportedError::Other(
+                        "32-bit and 16-bit c don't have u128?".to_owned(),
+                    ))?,
                     PrimitiveTy::F32 => "float ",
                     PrimitiveTy::F64 => "double ",
                     PrimitiveTy::Bool => "bool ",


### PR DESCRIPTION
Except on wasm32 apparently.